### PR TITLE
[estimation]: add one odom in the link1 frame.

### DIFF
--- a/aerial_robot_estimation/include/aerial_robot_estimation/state_estimation.h
+++ b/aerial_robot_estimation/include/aerial_robot_estimation/state_estimation.h
@@ -459,6 +459,7 @@ namespace aerial_robot_estimation
     ros::NodeHandle nh_;
     ros::NodeHandle nhp_;
     ros::Publisher full_state_pub_, baselink_odom_pub_, cog_odom_pub_;
+    ros::Publisher link1_odom_pub_;
     tf2_ros::TransformBroadcaster br_;
     ros::Timer state_pub_timer_;
 

--- a/aerial_robot_model/include/aerial_robot_model/model/aerial_robot_model.h
+++ b/aerial_robot_model/include/aerial_robot_model/model/aerial_robot_model.h
@@ -56,6 +56,9 @@
 #include <urdf/model.h>
 #include <vector>
 
+// for contact point
+#include <tf/tf.h>
+
 namespace aerial_robot_model {
 
   //Basic Aerial Robot Model
@@ -167,6 +170,11 @@ namespace aerial_robot_model {
     virtual bool stabilityCheck(bool verbose = true);
 
     KDL::JntArray convertEigenToKDL(const Eigen::VectorXd& joint_vector);
+
+    void convertFromCoGToLink1(const tf::Vector3& cog_pos_in_w, const tf::Vector3& cog_vel_in_w,
+                               const tf::Quaternion& cog_quat, const tf::Vector3& cog_omega,
+                               tf::Vector3& link1_pos_in_w, tf::Vector3& link1_vel_in_w,
+                               tf::Quaternion& link1_quat, tf::Vector3& link1_omega) const;
 
   private:
 


### PR DESCRIPTION
This pull request adds support for publishing the odometry of the `link1` segment in the aerial robot's state estimation. The main changes introduce a new publisher for `link1` odometry, implement the necessary coordinate transformation from the center of gravity (CoG) to `link1`, and update the state publishing logic to include this new odometry message.

<img width="306" height="138" alt="Screenshot from 2025-08-12 19-54-36" src="https://github.com/user-attachments/assets/6f850734-3323-4bce-8510-952060f117e3" />
